### PR TITLE
Fix oryx build failures by updating Azure.Identity NuGet and address security vulnerability

### DIFF
--- a/src/BuildScriptGenerator.Common/BuildScriptGenerator.Common.csproj
+++ b/src/BuildScriptGenerator.Common/BuildScriptGenerator.Common.csproj
@@ -16,7 +16,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\CommonFiles\AssemblyVersion.proj" />
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />


### PR DESCRIPTION
Ref: 
- https://github.com/devcontainers/images/actions/runs/9568568283/job/26379092325#step:3:18232
- https://github.com/advisories/GHSA-m5vv-6r4h-3vj9

Similar to https://github.com/microsoft/Oryx/pull/2422

Oryx build is failing for the `universal` image with the following error 👇  This is blocking a newer release of the image. 

![image](https://github.com/user-attachments/assets/c6fda117-90a0-45df-929e-8e1e85423aa7)


This PR fixes oryx build, as well as patches the security vulnerability.

